### PR TITLE
feat(ui): limit CheckboxGrid to display only two rows of items

### DIFF
--- a/components/containers/profile-list/components/profile-list-hero-filters/profile-list-hero-filters.tsx
+++ b/components/containers/profile-list/components/profile-list-hero-filters/profile-list-hero-filters.tsx
@@ -82,6 +82,7 @@ export const ProfileListHeroFilters = () => {
           )}
         </div>
         <CheckboxGrid
+          initialVisibleCount={12}
           isFetching={filters.profileSectorsFilter.options?.isFetching}
           isLoading={filters.profileSectorsFilter.options?.isLoading}
           selected={filters.profileSectorsFilter.value}
@@ -107,6 +108,7 @@ export const ProfileListHeroFilters = () => {
           )}
         </div>
         <CheckboxGrid
+          initialVisibleCount={12}
           isFetching={filters.productTypesFilter.options?.isFetching}
           isLoading={filters.productTypesFilter.options?.isLoading}
           selected={filters.productTypesFilter.value}


### PR DESCRIPTION
I limited the grid to show only 12 items, as is in the first  checkbox grid but not in the rest of them, i hope this solution is decent
![image](https://github.com/user-attachments/assets/54ad633f-29b8-435f-81bd-4033e7378f6f)
