### PR TITLE
Update social icon GitHub twitter

### DIFF
--- a/components/containers/header/header.tsx
+++ b/components/containers/header/header.tsx
@@ -41,7 +41,7 @@ const cloneRepoButton = (
     rel="noopener noreferrer"
   >
     <Button className="w-full md:w-fit" variant="outline">
-      <SiGithub className="mr-2" size={18} />
+      <SiTwitter className="mr-2" size={18} />
       {siteConfig.header.githubButton.label}
     </Button>
   </Link>

--- a/components/containers/header/header.tsx
+++ b/components/containers/header/header.tsx
@@ -3,6 +3,7 @@
 import Link from 'next/link';
 import { MenuIcon } from 'lucide-react';
 import { SiGithub } from 'react-icons/si';
+import { SiTwitter } from 'react-icons/si';
 
 import { Sheet, SheetContent, SheetTrigger } from '@/components/ui/sheet';
 import { Button } from '@/components/ui/button';

--- a/components/containers/header/header.tsx
+++ b/components/containers/header/header.tsx
@@ -3,7 +3,7 @@
 import Link from 'next/link';
 import { MenuIcon } from 'lucide-react';
 import { SiGithub } from 'react-icons/si';
-import { SiTwitter } from 'react-icons/si';
+import { FaTwitter } from 'react-icons/fa';
 
 import { Sheet, SheetContent, SheetTrigger } from '@/components/ui/sheet';
 import { Button } from '@/components/ui/button';
@@ -42,7 +42,7 @@ const cloneRepoButton = (
     rel="noopener noreferrer"
   >
     <Button className="w-full md:w-fit" variant="outline">
-      <SiTwitter className="mr-2" size={18} />
+      <FaTwitter className="mr-2" size={18} />
       {siteConfig.header.githubButton.label}
     </Button>
   </Link>


### PR DESCRIPTION
This is needed as often we want to point people to a social account, not a github. So this is a simple fix. 

@jordanshatcher as an FYI, this was requested by POT

It is a simple change so can be done tomorrow, or get someone else to review? Just as an example of our current process. 

Asked @olegovsyannikov to review just so he can see this repo at least one time, will be an important one for us to also do work on in the future. 

Docs here should be updated with more info about the standard config file as this will be used across alot of TGS components in the future. 

This one: https://github.com/The-Grid-Data/Explorer/blob/main/lib/config/default-config.json 

As can be seen in vercel, there are quite a few of these. 

Also as an FYI to @hugomoura10 just to see this one time 